### PR TITLE
misuse of API … call with `true` deletes this object's data

### DIFF
--- a/app/code/Magento/Customer/Model/Account/Redirect.php
+++ b/app/code/Magento/Customer/Model/Account/Redirect.php
@@ -144,7 +144,7 @@ class Redirect
                 ->forward($this->session->getBeforeAction());
         } else {
             $result = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
-            $result->setUrl($this->session->getBeforeAuthUrl(true));
+            $result->setUrl($this->session->getBeforeAuthUrl());
         }
         return $result;
     }


### PR DESCRIPTION
### Description (*)

misuse of API, ... When `true`, the resultant getData('before_auth_url',true) call shifts the context to the specified field, expecting it to be an array.  The previous Data context is replaced.  In this case, the field is not an array and all of the previous data on this object now returns NULL.  I don't believe loss of this, and all of the other fields was the intended behavior.

In my case, all subsequent requests for the redirect URL failed, returning a NULL redirect.

```
diff ../magento2/app/code/Magento/Customer/Model/Account/Redirect.php  ./html/vendor/magento/module-customer/Model/Account/Redirect.php
147c147
<             $result->setUrl($this->session->getBeforeAuthUrl(true));
---
>             $result->setUrl($this->session->getBeforeAuthUrl());

```
### Fixed Issues (if relevant)
unknown -- I needed this change to fix my deployment

### Manual testing scenarios (*)
I would encounter this by signing out and then signing in, ... The account would sign in correctly, but the configured redirect page was incorrectly cleared to NULL.

### Contribution checklist (*)
 - [√] Pull request has a meaningful description of its purpose
 - [√] All commits are accompanied by meaningful commit messages
 - [n/a] All new or changed code is covered with unit/integration tests (if applicable)
 - [n/a] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [unknown] All automated tests passed successfully (all builds are green)
