### PR TITLE
check not_is_null before use

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/MetadataProcessor.php
+++ b/lib/internal/Magento/Framework/App/Config/MetadataProcessor.php
@@ -83,8 +83,10 @@ class MetadataProcessor
         foreach ($this->_metadata as $path => $metadata) {
             /** @var \Magento\Framework\App\Config\Data\ProcessorInterface $processor */
             $processor = $this->_processorFactory->get($metadata['backendModel']);
-            $value = $processor->processValue($this->_getValue($data, $path));
-            $this->_setValue($data, $path, $value);
+            if (!is_null($processor)) {
+                $value = $processor->processValue($this->_getValue($data, $path));
+                $this->_setValue($data, $path, $value);
+            }
         }
         return $data;
     }


### PR DESCRIPTION
### Description (*)

During updates, especially when modules are being removed, some configuration vestiges will cause the `bin/magento setup:upgrade` to fail, because they are actually missing and cannot be loaded.

This is primarily a convenience to the developer, … with this change the configuration vestiges, that are cleaned up once the bin/magento setup:upgrade completes are able to run to completion.  Without it, the `bin/magento setup:upgrade` fails to start.

### Changes

When a misconfigured backend module cannot be found, null is returned.  `bin/magento setup:upgrade` then exits, attempting to load a NULL object.

To alleviate this, the returned object is tested (`!is_null()`) before being called.

### Related Pull Requests
https://github.com/ergohack/magento2/pull/2

### Fixed Issues (if relevant)
unknown

### Manual testing scenarios (*)

Remove a module that has a `backend_model` configured.  Then run `bin/magento setup:upgrade`.  I think all of the professional modules are fine, … I was removing a third‑party module that didn't cleanup correctly until after the `bin/magento setup:upgrade` completed.

That is why I think this check is more of a convenience to developers, as I believe most modules behave properly.

### Contribution checklist (*)
 - [√] Pull request has a meaningful description of its purpose
 - [√] All commits are accompanied by meaningful commit messages
 - [n/a] All new or changed code is covered with unit/integration tests (if applicable)
 - [n/a] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [unknown] All automated tests passed successfully (all builds are green)