### PR TITLE
avoid a misconfiguration infinite loop

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
@@ -156,6 +156,7 @@ class Config implements ConfigInterface
     public function getInstanceType($instanceName)
     {
         while (isset($this->_virtualTypes[$instanceName])) {
+            if ($instanceName == $this->_virtualTypes[$instanceName]) break;
             $instanceName = $this->_virtualTypes[$instanceName];
         }
         return $instanceName;


### PR DESCRIPTION
### Description (*)

The virtual type configurations, in `di.xml` files, are not supposed to be self‑referential, … but if they ever are this function will spin in an infinite loop.

### Changes

Added a test to avoid a self‑referential mapping, returning the reference instead of endlessly spinning.

### Fixed Issues (if relevant)
unknown

### Manual testing scenarios (*)
Configure a `di.xml` `<virtualType …>` node to be self‑referential (i.e. not actually virtual).  This will cause the app to spin, infinitely, on the dereferencing attempt.

### Contribution checklist (*)
 - [√] Pull request has a meaningful description of its purpose
 - [√] All commits are accompanied by meaningful commit messages
 - [n/a] All new or changed code is covered with unit/integration tests (if applicable)
 - [n/a] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [unknown] All automated tests passed successfully (all builds are green)